### PR TITLE
Remove some extraneous autocommands

### DIFF
--- a/autoload/parinfer.vim
+++ b/autoload/parinfer.vim
@@ -37,7 +37,7 @@ function! parinfer#init() abort
     lua parinfer.enter_buffer()
 
     augroup parinfer
-        autocmd! CursorMoved,InsertCharPre,InsertEnter,TextChanged,TextChangedI,TextChangedP <buffer> call v:lua.parinfer.process_buffer()
+        autocmd! TextChanged,TextChangedI,TextChangedP <buffer> call v:lua.parinfer.process_buffer()
     augroup END
 
     if !get(b:, 'parinfer_no_maps', get(g:, 'parinfer_no_maps', 0))


### PR DESCRIPTION
Removes CursorMoved, InsertCharPre, and InsertEnter. parinfer is now only
invoked for the TextChanged autocommands, which means it will fire much
less often but without any (significant) difference in results.
